### PR TITLE
getTexture: convert from straight to premultiplied alpha.

### DIFF
--- a/renderer/render.go
+++ b/renderer/render.go
@@ -114,7 +114,19 @@ func vmultiply(v, vbuf []ebiten.Vertex, bmin, bmax image.Point) {
 
 func getTexture(tex *imgui.RGBA32Image) *ebiten.Image {
 	n := tex.Width * tex.Height
-	pix := (*[1 << 28]uint8)(tex.Pixels)[: n*4 : n*4]
+	srcPix := (*[1 << 28]uint8)(tex.Pixels)[: n*4 : n*4]
+	pix := make([]uint8, n*4)
+	// Note: Ebiten expects colors in premultiplied-alpha form.
+	// However, the imgui library exports pixmaps in straight-alpha form.
+	// Also, not doing this modification in-place,
+	// as srcPix points right into an imgui-owned data structure.
+	for i := 0; i < n; i++ {
+		alpha := uint16(srcPix[4*i+3])
+		pix[4*i] = uint8((uint16(srcPix[4*i]) * alpha + 127) / 255)
+		pix[4*i+1] = uint8((uint16(srcPix[4*i+1]) * alpha + 127) / 255)
+		pix[4*i+2] = uint8((uint16(srcPix[4*i+2]) * alpha + 127) / 255)
+		pix[4*i+3] = uint8(alpha)
+	}
 	img := ebiten.NewImage(tex.Width, tex.Height)
 	img.ReplacePixels(pix)
 	return img


### PR DESCRIPTION
imgui uses straight alpha (see e.g.
http://docs.ros.org/en/kinetic/api/librealsense2/html/imgui__draw_8cpp_source.html#l01108),
while Ebiten expects premultiplied alpha (see
https://pkg.go.dev/github.com/hajimehoshi/ebiten/v2#Image.ReplacePixels). So
sadly a conversion is necessary. Not doing the conversion in-place, as the font
pixel data is pointing into a memory area owned by imgui, which could lead to
double converting the same data (just in the examples it does not really
matter).

In Ebiten 2.3, a min() statement was removed from the shader to improve
performance, which "accidentally" had fixed up textures like the ones imgui
produced; after this change, ebiten-imgui is compatible both with Ebiten 2.2
and 2.3.

Fixes https://github.com/hajimehoshi/ebiten/issues/2080